### PR TITLE
Added functionality to update a project's data

### DIFF
--- a/src/handlers/RequestHandler.ts
+++ b/src/handlers/RequestHandler.ts
@@ -1,4 +1,5 @@
 import updateProjectStatusProcessor from '../ixo/processor/UpdateProjectStatusProcessor';
+import updateProjectDocProcessor from '../ixo/processor/UpdateProjectDocProcessor';
 import createProjectProcessor from '../ixo/processor/CreateProjectProcessor';
 import createAgentProcessor from '../ixo/processor/CreateAgentProcessor';
 import evaluateClaimsProcessor from '../ixo/processor/EvaluateClaimsProcessor';
@@ -68,6 +69,12 @@ export const RequestLookupHandler: any = {
     });
   },
 
+  'updateProjectDoc': (args: any) => {
+    return new Promise((resolve: Function, reject: Function) => {
+      resolve(updateProjectDocProcessor.process(args));
+    });
+  },
+
   'fundProject': (args: any) => {
     return new Promise((resolve: Function, reject: Function) => {
       resolve(fundProjectProcessor.process(args));
@@ -81,6 +88,9 @@ const lookupProcessor: any = {
   },
   'project/UpdateProjectStatus': (jsonResponseMsg: any) => {
     updateProjectStatusProcessor.handleAsyncProjectStatusResponse(jsonResponseMsg)
+  },
+  'project/UpdateProjectDoc': (jsonResponseMsg: any) => {
+    updateProjectDocProcessor.handleAsyncProjectDocResponse(jsonResponseMsg)
   },
   'project/CreateAgent': (jsonResponseMsg: any) => {
     createAgentProcessor.handleAsyncCreateAgentResponse(jsonResponseMsg)

--- a/src/ixo/model/ProjectDocModel.ts
+++ b/src/ixo/model/ProjectDocModel.ts
@@ -1,0 +1,16 @@
+import {Document, Model, model, Schema} from "mongoose";
+
+
+export interface IProjectDocModel extends Document {
+  doc: string
+}
+
+const ProjectDocSchema: Schema = new Schema({
+  doc: String
+}, {strict: false});
+
+ProjectDocSchema.pre("save", function (next) {
+  next();
+});
+
+export const ProjectDoc: Model<IProjectDocModel> = model<IProjectDocModel>("ProjectDoc", ProjectDocSchema);

--- a/src/ixo/processor/CreateProjectProcessor.ts
+++ b/src/ixo/processor/CreateProjectProcessor.ts
@@ -52,6 +52,7 @@ export class CreateProjectProcessor extends AbstractHandler {
   updateCapabilities = (request: Request) => {
     this.addCapabilities(request.projectDid, [request.projectDid, request.signature.creator], 'FundProject');
     this.addCapabilities(request.projectDid, [request.projectDid, request.signature.creator], 'UpdateProjectStatus');
+    this.addCapabilities(request.projectDid, [request.projectDid, request.signature.creator], 'UpdateProjectDoc');
     this.addCapabilities(request.projectDid, [request.projectDid, request.signature.creator], 'UpdateAgentStatus');
     this.addCapabilities(request.projectDid, ['did:sov:*', 'did:ixo:*'], 'CreateAgent');
     this.addCapabilities(request.projectDid, [request.signature.creator], 'ListAgents');

--- a/src/ixo/processor/CreateProjectProcessor.ts
+++ b/src/ixo/processor/CreateProjectProcessor.ts
@@ -1,6 +1,7 @@
 import InitHandler from '../../handlers/InitHandler';
 import {AbstractHandler} from '../../handlers/AbstractHandler';
 import {Project} from '../model/ProjectModel';
+import {ProjectDoc} from "../model/ProjectDocModel";
 import {Request} from "../../handlers/Request";
 import {dateTimeLogger} from '../../logger/Logger';
 import walletService from '../../service/WalletService';
@@ -25,6 +26,7 @@ export class CreateProjectProcessor extends AbstractHandler {
           };
           const sanitizedData = xss.sanitize(obj);
           Project.create({...sanitizedData, projectDid: cached.projectDid});
+          ProjectDoc.create({...sanitizedData, projectDid: cached.projectDid});
           Project.emit('postCommit', obj, cached.projectDid);
           console.log(dateTimeLogger() + ' create project transaction completed successfully');
         } else {

--- a/src/ixo/processor/UpdateProjectDocProcessor.ts
+++ b/src/ixo/processor/UpdateProjectDocProcessor.ts
@@ -28,6 +28,7 @@ export class UpdateProjectDocProcessor extends AbstractHandler {
           const sanitizedData = xss.sanitize(obj);
           ProjectDoc.create({...sanitizedData, projectDid: cached.projectDid});
           ProjectDoc.emit('postCommit', obj, cached.projectDid);
+          // TODO: update project doc in Project database, probably using Project.update(...)
           console.log(dateTimeLogger() + ' Update project doc transaction completed successfully');
         } else {
           let retry: number = retries || 0;

--- a/src/ixo/processor/UpdateProjectDocProcessor.ts
+++ b/src/ixo/processor/UpdateProjectDocProcessor.ts
@@ -1,0 +1,79 @@
+import {AbstractHandler} from '../../handlers/AbstractHandler';
+import {ProjectDoc} from '../model/ProjectDocModel';
+import {Request} from "../../handlers/Request";
+import {BlockchainMode} from '../common/shared';
+import {dateTimeLogger} from '../../logger/Logger';
+import Cache from '../../Cache';
+import xss from "../../Xss";
+
+export class UpdateProjectDocProcessor extends AbstractHandler {
+
+  updateCapabilities = (request: Request) => {
+  };
+
+  handleAsyncProjectDocResponse = (jsonResponseMsg: any, retries?: number) => {
+    //successful doc response
+    Cache.get(jsonResponseMsg.txHash)
+      .then((cached) => {
+        if (cached != undefined) {
+          console.log(dateTimeLogger() + ' updating the project doc capabilities');
+          this.updateCapabilities(cached);
+          console.log(dateTimeLogger() + ' commit project doc to Elysian');
+          const obj = {
+            ...cached.data,
+            txHash: jsonResponseMsg.txHash,
+            _creator: cached.signature.creator,
+            _created: cached.signature.created
+          };
+          const sanitizedData = xss.sanitize(obj);
+          ProjectDoc.create({...sanitizedData, projectDid: cached.projectDid});
+          ProjectDoc.emit('postCommit', obj, cached.projectDid);
+          console.log(dateTimeLogger() + ' Update project doc transaction completed successfully');
+        } else {
+          let retry: number = retries || 0;
+          if (retry <= 3) {
+            retry++;
+            setTimeout(() => {
+              console.log(dateTimeLogger() + ' retry cached update project transaction for %s ', jsonResponseMsg.txHash);
+              this.handleAsyncProjectDocResponse(jsonResponseMsg, retry)
+            }, 2000)
+          } else {
+            //TODO we will want to get the transaction from the tranaction log and try the commit again. he transaction has already been accepted by the chain so we need to
+            //force the data into the DB
+            console.log(dateTimeLogger() + ' cached update project not found for transaction %s ', jsonResponseMsg.txHash);
+          }
+        }
+      })
+      .catch(() => {
+        //TODO we will want to get the transaction from the tranaction log and try the commit again. he transaction has already been accepted by the chain so we need to
+        //force the data into the DB
+        console.log(dateTimeLogger() + ' exception caught for handleAsyncProjectDocResponse');
+      });
+
+  };
+
+  msgToPublish = (txHash: any, request: Request) => {
+    return new Promise((resolve: Function, reject: Function) => {
+      const data = {
+        data: {
+          // TODO: new project doc (probably) goes here
+        },
+        txHash: txHash,
+        senderDid: request.signature.creator,
+        projectDid: request.projectDid
+      };
+      const sanitizedData = xss.sanitize(data);
+      const msg = {type: "project/UpdateProjectDoc", value: sanitizedData};
+      resolve(this.messageForBlockchain(msg, request.projectDid, BlockchainMode.block));
+    });
+  };
+
+  process = (args: any) => {
+    console.log(dateTimeLogger() + ' start new Update Project Doc transaction ');
+    // TODO: add check to make sure project status is one of ["NULL", "CREATED", "PENDING", "FUNDED"]
+    //       but in any case this is enforced by the blockchain, so we might want to just rely on that.
+    return this.createTransaction(args, 'UpdateProjectDoc', ProjectDoc, undefined);
+  }
+}
+
+export default new UpdateProjectDocProcessor();

--- a/src/ixo/processor/UpdateProjectDocProcessor.ts
+++ b/src/ixo/processor/UpdateProjectDocProcessor.ts
@@ -68,8 +68,6 @@ export class UpdateProjectDocProcessor extends AbstractHandler {
         }
       })
       .catch(() => {
-        //TODO we will want to get the transaction from the tranaction log and try the commit again. he transaction has already been accepted by the chain so we need to
-        //force the data into the DB
         console.log(dateTimeLogger() + ' exception caught for handleAsyncProjectDocResponse');
       });
 

--- a/src/ixo/processor/UpdateProjectDocProcessor.ts
+++ b/src/ixo/processor/UpdateProjectDocProcessor.ts
@@ -61,8 +61,6 @@ export class UpdateProjectDocProcessor extends AbstractHandler {
               this.handleAsyncProjectDocResponse(jsonResponseMsg, retry)
             }, 2000)
           } else {
-            //TODO we will want to get the transaction from the tranaction log and try the commit again. he transaction has already been accepted by the chain so we need to
-            //force the data into the DB
             console.log(dateTimeLogger() + ' cached update project not found for transaction %s ', jsonResponseMsg.txHash);
           }
         }

--- a/src/ixo/processor/UpdateProjectDocProcessor.ts
+++ b/src/ixo/processor/UpdateProjectDocProcessor.ts
@@ -6,7 +6,6 @@ import {BlockchainMode} from '../common/shared';
 import {dateTimeLogger} from '../../logger/Logger';
 import Cache from '../../Cache';
 import xss from "../../Xss";
-import updateAgentStatusProcessor from "./UpdateAgentStatusProcessor";
 
 export class UpdateProjectDocProcessor extends AbstractHandler {
 
@@ -39,10 +38,11 @@ export class UpdateProjectDocProcessor extends AbstractHandler {
                     {_id: prevProject._id},
                     {
                       ...cached.data.data,
-                      projectDid: prevProjectJSON.projectDid,
                       txHash: prevProjectJSON.txHash,
                       _creator: prevProjectJSON._creator,
-                      _created: prevProjectJSON._created}
+                      _created: prevProjectJSON._created,
+                      projectDid: prevProjectJSON.projectDid
+                    }
                 ).exec()
                 console.log(dateTimeLogger() + ' Update project doc transaction completed successfully');
               } else {


### PR DESCRIPTION
A `MsgUpdateProjectDoc` was [previously added](https://github.com/ixofoundation/ixo-blockchain/pull/230) to ixo-blockchain's `project` module, which allows one to update an existing project's `Data` field. However, since projects are interacted with through ixo-cellnode, support from the ixo-cellnode side was required to make this feature more useful. The following are the main updates made to ixo-cellnode.
- when creating a new project, we now store a copy of its `Data` field in Cellnode's `projectdocs` DB
- `handleAsyncProjectDocResponse` finds the existing project in Cellnode's `projects` DB and updates its `Data` field, and stores a copy of the new `Data` in Cellnode's `projectdocs` DB
- `msgToPublish` constructs the updated project object to be broadcasted to ixo-blockchain.